### PR TITLE
export static version number

### DIFF
--- a/tasks/bender_collect_jenkins_env.coffee
+++ b/tasks/bender_collect_jenkins_env.coffee
@@ -146,6 +146,8 @@ module.exports = (grunt) ->
             setRequiredBuildConfig 'bender.build.version', "#{majorVersion}.#{minorVersion}"
             setRequiredBuildConfig 'bender.build.versionWithStaticPrefix', "static-#{majorVersion}.#{minorVersion}"
 
+            utils.writeFile grunt.config.get('bender.build.versionWithStaticPrefix') path.join(grunt.config.get('bender.build.workspace'), '.version')
+
             # Metric client for other tasks to use
             grunt.config.set 'bender.metric.namespace', (process.env.METRIC_KEY_PREFIX or process.env.GRAPHITE_NAMESPACE)
             grunt.config.set 'bender.graphite.server', process.env.GRAPHITE_SERVER


### PR DESCRIPTION
@timmfin @tpetr 
make the static version number available as an env variable so other surrounding tasks/scripts/build processes can use it